### PR TITLE
fix: resolve path of injectedGlobals relative to config file

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@stencil/sass",
-  "version": "1.4.0",
+  "version": "2.0.0-0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@stencil/sass",
-  "version": "1.4.0",
+  "version": "2.0.0-0",
   "license": "MIT",
   "main": "dist/index.js",
   "module": "dist/index.mjs",

--- a/src/util.ts
+++ b/src/util.ts
@@ -36,20 +36,23 @@ export function getRenderOptions(opts: d.PluginOptions, sourceText: string, file
   const injectGlobalPaths = Array.isArray(opts.injectGlobalPaths) ? opts.injectGlobalPaths.slice() : [];
 
   if (injectGlobalPaths.length > 0) {
+    const baseInjectPath = context.config.configPath? path.dirname(context.config.configPath) : context.config.rootDir;
+
     // automatically inject each of these paths into the source text
     const injectText = injectGlobalPaths.map((injectGlobalPath) => {
       const includesNamespace = Array.isArray(injectGlobalPath);
       let importPath = includesNamespace ? injectGlobalPath[0] as string : injectGlobalPath as string;
 
       if (!path.isAbsolute(importPath)) {
-        // convert any relative paths to absolute paths relative to the project root
+        const injectedPath = path.join(baseInjectPath, importPath);
 
+        // convert any relative paths to absolute paths relative to the project root
         if (context.sys && typeof context.sys.normalizePath === 'function') {
           // context.sys.normalizePath added in stencil 1.11.0
-          importPath = context.sys.normalizePath(path.join(context.config.rootDir, importPath));
+          importPath = context.sys.normalizePath(injectedPath);
         } else {
           // TODO, eventually remove normalizePath() from @stencil/sass
-          importPath = normalizePath(path.join(context.config.rootDir, importPath));
+          importPath = normalizePath(injectedPath);
         }
       }
 
@@ -175,7 +178,7 @@ export function getModuleId(orgImport: string) {
   }
 
   return m;
-};
+}
 
 const EXTENDED_PATH_REGEX = /^\\\\\?\\/;
 const NON_ASCII_REGEX = /[^\x00-\x80]+/;

--- a/test/utils.spec.ts
+++ b/test/utils.spec.ts
@@ -8,6 +8,7 @@ describe('getRenderOptions', () => {
   const fileName = '/some/path/file-name.scss';
   const context: d.PluginCtx = {
     config: {
+      configPath: '/Users/my/app/stencil.config.ts',
       rootDir: '/Users/my/app/',
       srcDir: '/Users/my/app/src/',
     },


### PR DESCRIPTION
resolve path of injectedGlobals relative to config file (fallback to rootDir if optional configPath is not set)

fixes https://github.com/ionic-team/stencil-sass/issues/49

