### PR TITLE
feat: add optional `quietDepts` config option to silence deprecation warnings

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -18,7 +18,9 @@ import { sass } from '@stencil/sass';
 
 export const config: Config = {
   plugins: [
-    sass()
+    sass({
+      // Optional config options
+    })
   ]
 };
 ```
@@ -30,6 +32,19 @@ During development, this plugin will kick-in for `.scss` or `.sass` style urls, 
 
 Sass options can be passed to the plugin within the stencil config, which are used directly by `sass`. Please reference [sass documentation](https://www.npmjs.com/package/sass) for all available options. Note that this plugin automatically adds the component's directory to the `includePaths` array.
 
+### Silence Deprecation Warnings
+
+The `quietDepts` option can be used to silence Sass deprecation warnings, including the @import rule deprecation warning that will be removed in Dart Sass 3.0.0. To enable this:
+
+```js
+exports.config = {
+  plugins: [
+    sass({
+      quietDepts: true
+    })
+  ]
+};
+```
 
 ### Inject Globals Sass Paths
 

--- a/src/declarations.ts
+++ b/src/declarations.ts
@@ -92,6 +92,11 @@ export interface PluginOptions {
    * The value will be emitted as `sourceRoot` in the source map information.
    */
   sourceMapRoot?: string;
+
+  /**
+   * When true, silences deprecation warnings from Sass, including @import rule deprecation warnings.
+   */
+  quietDepts?: boolean;
 }
 
 export type ImporterReturnType = { file: string } | { contents: string } | Error | null;

--- a/src/util.ts
+++ b/src/util.ts
@@ -146,7 +146,19 @@ export function getRenderOptions(
     renderOpts.importer = importers;
   }
 
-  renderOpts.silenceDeprecations = [...(renderOpts.silenceDeprecations ?? []), 'legacy-js-api'];
+  // Initialize silenceDeprecations array if it doesn't exist
+  renderOpts.silenceDeprecations = renderOpts.silenceDeprecations || [];
+
+  // Add legacy-js-api to silenceDeprecations
+  renderOpts.silenceDeprecations.push('legacy-js-api');
+
+  // If quietDepts is true, add 'import' to silenceDeprecations to silence @import deprecation warnings
+  if (opts.quietDepts) {
+    renderOpts.silenceDeprecations.push('import');
+  }
+
+  // Remove the non-standard quietDepts option
+  delete (renderOpts as any).quietDepts;
 
   return renderOpts;
 }


### PR DESCRIPTION
<!-- Please refer to our contributing documentation for any questions on submitting a pull request, or let us know here if you need any help: https://github.com/stenciljs/core/blob/main/CONTRIBUTING.md -->

## Pull request checklist

Please check if your PR fulfills the following requirements:
- [x] Docs have been reviewed and added / updated if needed (for bug fixes / features)
- [x] Build (`npm run build`) was run locally and any changes were pushed
- [x] Tests (`npm test`) were run locally and passed
- [x] Prettier (`npm run prettier`) was run locally and passed

## Pull request type

<!-- Please do not submit updates to dependencies unless it fixes an issue. --> 

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. --> 

Please check the type of change your PR introduces:
- [ ] Bugfix
- [x] Feature
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

GitHub Issue Number: #378 

## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->

Users can now silence deprecation warnings by setting the `quietDepts` config option in the `stencil.config.ts`:

```ts
import { Config } from '@stencil/core';
import { sass } from '@stencil/sass';

export const config: Config = {
  ...
  plugins: [
    sass({
      quietDepts: true
    })
  ]
  ...
};
```

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## Testing

<!-- Please describe the steps you took to test the changes in this PR. These steps can be programmatic (e.g. unit tests) and/or manual. -->

## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->
