### PR TITLE
fix: change @import to a @use with wildcard

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -12,6 +12,7 @@ npm install @stencil/sass --save-dev
 Next, within the project's stencil config, import the plugin and add it to the config's `plugins` property:
 
 #### stencil.config.ts
+
 ```ts
 import { Config } from '@stencil/core';
 import { sass } from '@stencil/sass';
@@ -20,38 +21,32 @@ export const config: Config = {
   plugins: [
     sass({
       // Optional config options
-    })
-  ]
+    }),
+  ],
 };
 ```
 
 During development, this plugin will kick-in for `.scss` or `.sass` style urls, and precompile them to CSS.
 
-
 ## Options
 
 Sass options can be passed to the plugin within the stencil config, which are used directly by `sass`. Please reference [sass documentation](https://www.npmjs.com/package/sass) for all available options. Note that this plugin automatically adds the component's directory to the `includePaths` array.
 
-
 ### Inject Globals Sass Paths
 
-The `injectGlobalPaths` config is an array of paths that automatically get added as `@import` declarations to all components. This can be useful to inject Sass variables, mixins and functions to override defaults of external collections. For example, apps can override default Sass variables of [Ionic components](https://www.npmjs.com/package/@ionic/core). Relative paths within `injectGlobalPaths` should be relative to the stencil config file.
+The `injectGlobalPaths` config is an array of paths that automatically get added as `@use` with a wildcard (to avoid namespacing) declarations to all components. This can be useful to inject Sass variables, mixins and functions to override defaults of external collections. For example, apps can override default Sass variables of [Ionic components](https://www.npmjs.com/package/@ionic/core). Relative paths within `injectGlobalPaths` should be relative to the stencil config file.
 
 ```js
 exports.config = {
   plugins: [
     sass({
-      injectGlobalPaths: [
-        'src/globals/variables.scss',
-        'src/globals/mixins.scss'
-      ]
-    })
-  ]
+      injectGlobalPaths: ['src/globals/variables.scss', 'src/globals/mixins.scss'],
+    }),
+  ],
 };
 ```
 
 Note that each of these files are always added to each component, so in most cases they shouldn't contain CSS because it'll get duplicated in each component. Instead, `injectGlobalPaths` should only be used for Sass variables, mixins and functions, but does not contain any CSS.
-
 
 ### Warning Controls
 
@@ -67,21 +62,19 @@ exports.config = {
       // Silence all dependency warnings
       quietDeps: true,
       // Silence specific deprecation warnings
-      silenceDeprecations: ['import']
-    })
-  ]
+      silenceDeprecations: ['import'],
+    }),
+  ],
 };
 ```
 
-
 ## Related
 
-* [sass](https://www.npmjs.com/package/sass)
-* [Stencil](https://stenciljs.com/)
-* [Ionic Discord](https://chat.stenciljs.com/)
-* [Ionic Components](https://www.npmjs.com/package/@ionic/core)
-* [Ionicons](http://ionicons.com/)
-
+- [sass](https://www.npmjs.com/package/sass)
+- [Stencil](https://stenciljs.com/)
+- [Ionic Discord](https://chat.stenciljs.com/)
+- [Ionic Components](https://www.npmjs.com/package/@ionic/core)
+- [Ionicons](http://ionicons.com/)
 
 ## Contributing
 

--- a/src/util.ts
+++ b/src/util.ts
@@ -74,7 +74,7 @@ export function getRenderOptions(
 
         const importTerminator = renderOpts.indentedSyntax ? '\n' : ';';
 
-        return `@import "${injectGlobalPath}"${importTerminator}`;
+        return `@use "${injectGlobalPath}" as *${importTerminator}`;
       })
       .join('');
 

--- a/test/utils.spec.ts
+++ b/test/utils.spec.ts
@@ -30,7 +30,7 @@ describe('getRenderOptions', () => {
       injectGlobalPaths: ['/my/global/variables.scss']
     };
     const output = util.getRenderOptions(input, sourceText, fileName, context);
-    expect(output.data).toBe(`@import "/my/global/variables.scss";body { color: blue; }`);
+    expect(output.data).toBe(`@use "/my/global/variables.scss" as *;body { color: blue; }`);
     // `injectGlobalPaths` in an input argument to the function, and does not exist on the return type (hence the type assertion)
     // we have this check to verify that we have not accidentally copied it to the generated configuration
     expect((output as any).injectGlobalPaths).toBeUndefined();


### PR DESCRIPTION
<!-- Please refer to our contributing documentation for any questions on submitting a pull request, or let us know here if you need any help: https://github.com/stenciljs/core/blob/main/CONTRIBUTING.md -->

## Pull request checklist

Please check if your PR fulfills the following requirements:
- [x] Docs have been reviewed and added / updated if needed (for bug fixes / features)
- [x] Build (`npm run build`) was run locally and any changes were pushed
- [x] Tests (`npm test`) were run locally and passed
- [x] Prettier (`npm run prettier`) was run locally and passed

## Pull request type

<!-- Please do not submit updates to dependencies unless it fixes an issue. --> 

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. --> 

Please check the type of change your PR introduces:
- [x] Bugfix
- [ ] Feature
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

GitHub Issue Number: 70


## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->

-
-
-

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

## Testing

I changed the line in @stencil/sass from `@import` to `@use` with a wildcard in my stencil project and it builds with no errors.

## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->
