### PR TITLE
fix: bound concurrent Sass renders

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -9,6 +9,47 @@ import { createResultsId, getRenderOptions, usePlugin } from './util';
  */
 type WithRequired<T, K extends keyof T> = T & { [P in K]-?: T[P] };
 
+type ConcurrencyLimiter = <T>(task: () => Promise<T>) => Promise<T>;
+
+function createConcurrencyLimiter(maxConcurrency: number): ConcurrencyLimiter {
+  let activeTasks = 0;
+  const pendingTasks: Array<() => void> = [];
+
+  return async <T>(task: () => Promise<T>): Promise<T> => {
+    if (activeTasks >= maxConcurrency) {
+      await new Promise<void>((resolve) => pendingTasks.push(resolve));
+    } else {
+      activeTasks += 1;
+    }
+
+    try {
+      return await task();
+    } finally {
+      const nextTask = pendingTasks.shift();
+
+      if (nextTask) {
+        nextTask();
+      } else {
+        activeTasks -= 1;
+      }
+    }
+  };
+}
+
+/**
+ * `sass-embedded` starts a compiler process for each legacy `render()` call.
+ * Reuse Stencil's worker limit to keep that process fan-out bounded.
+ */
+function getMaxConcurrentRenders(context: d.PluginCtx): number {
+  const maxConcurrentWorkers = context.config.maxConcurrentWorkers;
+
+  if (typeof maxConcurrentWorkers !== 'number' || !Number.isFinite(maxConcurrentWorkers)) {
+    return 1;
+  }
+
+  return Math.max(1, Math.floor(maxConcurrentWorkers));
+}
+
 /**
  * The entrypoint of the Stencil Sass plugin
  *
@@ -20,6 +61,8 @@ type WithRequired<T, K extends keyof T> = T & { [P in K]-?: T[P] };
  * @return the configured plugin
  */
 export function sass(opts: d.PluginOptions = {}): WithRequired<d.Plugin, 'transform'> {
+  let limitRenderConcurrency: ConcurrencyLimiter;
+
   return {
     name: 'sass',
     pluginType: 'css',
@@ -49,46 +92,51 @@ export function sass(opts: d.PluginOptions = {}): WithRequired<d.Plugin, 'transf
         return Promise.resolve(results);
       }
 
-      return new Promise<d.PluginTransformResults>((resolve) => {
-        try {
-          // invoke sass' compiler at this point
-          render(renderOpts, (err: LegacyException, sassResult: LegacyResult): void => {
-            if (err) {
-              loadDiagnostic(context, err, fileName);
-              results.code = `/**  sass error${err && err.message ? ': ' + err.message : ''}  **/`;
-              resolve(results);
-            } else {
-              results.dependencies = Array.from(sassResult.stats.includedFiles).map((dep) =>
-                context.sys.normalizePath(dep),
-              );
-              results.code = sassResult.css.toString();
+      limitRenderConcurrency ??= createConcurrencyLimiter(getMaxConcurrentRenders(context));
 
-              // write this css content to memory only so it can be referenced
-              // later by other plugins (autoprefixer)
-              // but no need to actually write to disk
-              context.fs.writeFile(results.id, results.code, { inMemoryOnly: true }).then(() => {
-                resolve(results);
+      return limitRenderConcurrency(
+        () =>
+          new Promise<d.PluginTransformResults>((resolve) => {
+            try {
+              // invoke sass' compiler at this point
+              render(renderOpts, (err: LegacyException, sassResult: LegacyResult): void => {
+                if (err) {
+                  loadDiagnostic(context, err, fileName);
+                  results.code = `/**  sass error${err && err.message ? ': ' + err.message : ''}  **/`;
+                  resolve(results);
+                } else {
+                  results.dependencies = Array.from(sassResult.stats.includedFiles).map((dep) =>
+                    context.sys.normalizePath(dep),
+                  );
+                  results.code = sassResult.css.toString();
+
+                  // write this css content to memory only so it can be referenced
+                  // later by other plugins (autoprefixer)
+                  // but no need to actually write to disk
+                  context.fs.writeFile(results.id, results.code, { inMemoryOnly: true }).then(() => {
+                    resolve(results);
+                  });
+                }
               });
-            }
-          });
-        } catch (e) {
-          // who knows, just good to play it safe here
-          const diagnostic: d.Diagnostic = {
-            level: 'error',
-            type: 'css',
-            language: 'scss',
-            header: 'sass error',
-            relFilePath: null,
-            absFilePath: null,
-            messageText: e,
-            lines: [],
-          };
-          context.diagnostics.push(diagnostic);
+            } catch (e) {
+              // who knows, just good to play it safe here
+              const diagnostic: d.Diagnostic = {
+                level: 'error',
+                type: 'css',
+                language: 'scss',
+                header: 'sass error',
+                relFilePath: null,
+                absFilePath: null,
+                messageText: e,
+                lines: [],
+              };
+              context.diagnostics.push(diagnostic);
 
-          results.code = `/**  sass error${e && e.message ? ': ' + e.message : ''}  **/`;
-          resolve(results);
-        }
-      });
+              results.code = `/**  sass error${e && e.message ? ': ' + e.message : ''}  **/`;
+              resolve(results);
+            }
+          }),
+      );
     },
   };
 }

--- a/test/concurrency.spec.ts
+++ b/test/concurrency.spec.ts
@@ -1,0 +1,114 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import type { LegacyException, LegacyResult, render } from 'sass-embedded';
+
+import { sass } from '../dist/index.js';
+import type { PluginCtx } from '../dist/declarations';
+
+const renderState = vi.hoisted(() => ({
+  active: 0,
+  failNext: false,
+  peak: 0,
+}));
+
+vi.mock('sass-embedded', async (importOriginal) => {
+  const original = await importOriginal<typeof import('sass-embedded')>();
+
+  return {
+    ...original,
+    render: vi.fn((_options, callback: Parameters<typeof render>[1]) => {
+      renderState.active += 1;
+      renderState.peak = Math.max(renderState.peak, renderState.active);
+
+      setTimeout(() => {
+        renderState.active -= 1;
+
+        if (renderState.failNext) {
+          renderState.failNext = false;
+          callback(
+            Object.assign(new Error('Sass compilation failed'), {
+              formatted: 'Error: Sass compilation failed',
+              status: 1,
+              file: 'stdin',
+              line: 1,
+              column: 1,
+            }) satisfies LegacyException,
+          );
+          return;
+        }
+
+        callback(undefined, {
+          css: Buffer.from('.fixture { color: red; }'),
+          stats: {
+            entry: 'data',
+            start: 0,
+            end: 1,
+            duration: 1,
+            includedFiles: [],
+          },
+        } satisfies LegacyResult);
+      }, 10);
+    }),
+  };
+});
+
+describe('render concurrency', () => {
+  let context: PluginCtx;
+
+  const transformAll = (count: number) => {
+    const plugin = sass();
+
+    return Promise.all(
+      Array.from({ length: count }, (_, index) =>
+        plugin.transform('.fixture { color: red; }', `/Users/my/app/src/fixture-${index}.scss`, context),
+      ),
+    );
+  };
+
+  beforeEach(() => {
+    renderState.active = 0;
+    renderState.failNext = false;
+    renderState.peak = 0;
+    context = {
+      config: {
+        rootDir: '/Users/my/app/',
+        srcDir: '/Users/my/app/src/',
+        maxConcurrentWorkers: 2,
+      },
+      cache: null as any,
+      sys: {
+        normalizePath: vi.fn((path: string) => path),
+      } as any,
+      fs: {
+        readFileSync: vi.fn(() => '.fixture { color: red; }'),
+        writeFile: vi.fn(() => Promise.resolve()),
+      } as any,
+      diagnostics: [],
+    };
+  });
+
+  it("limits concurrent Sass renders to Stencil's worker count", async () => {
+    const results = await transformAll(6);
+
+    expect(results).toHaveLength(6);
+    expect(renderState.peak).toBe(2);
+  });
+
+  it('continues rendering when Stencil workers are disabled', async () => {
+    context.config.maxConcurrentWorkers = 0;
+    const results = await transformAll(3);
+
+    expect(results).toHaveLength(3);
+    expect(renderState.peak).toBe(1);
+  });
+
+  it('continues queued renders after a Sass error', async () => {
+    context.config.maxConcurrentWorkers = 1;
+    renderState.failNext = true;
+    const results = await transformAll(3);
+
+    expect(results).toHaveLength(3);
+    expect(context.diagnostics).toHaveLength(1);
+    expect(renderState.peak).toBe(1);
+  });
+});


### PR DESCRIPTION
## Pull request checklist

- [x] Docs have been reviewed. No update is needed because this changes internal scheduling only.
- [x] Build (`pnpm run build`) was run locally and passed.
- [x] Tests (`pnpm test`) were run locally and passed.
- [x] Prettier (`pnpm run prettier`) was run locally and passed.

## Pull request type

- [x] Bugfix
- [ ] Feature
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other

## What is the current behavior?

Each concurrent transform calls `sass-embedded`'s legacy `render()` API. That API creates a compiler process per call, so Dart Sass process fan-out currently grows with the number of in-flight stylesheets.

GitHub Issue Number: #711

Closes #711.

## What is the new behavior?

- Sass render calls are queued per plugin instance and limited to Stencil's validated `maxConcurrentWorkers` value, which currently defaults to 8 and becomes 4 in CI.
- A worker setting of `0` still allows one render at a time, so disabling Stencil workers cannot deadlock Sass compilation.
- Existing plugin options, Sass output, diagnostics, and dependencies remain unchanged. No new runtime dependency or public option is introduced.

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

## Testing

- Added regression coverage that reproduced six simultaneous renders with `maxConcurrentWorkers: 2` before the change and now observes a peak of two.
- Covered `maxConcurrentWorkers: 0` and confirmed queued work continues after a Sass compilation error.
- `pnpm run build`, all 41 unit tests, formatting, package dry run, and the Stencil v4 integration fixture pass.
- The public 50-component reproduction produced the following results:

  | Metric | Stock 3.3.2 | This change |
  | --- | ---: | ---: |
  | Duration | 1.51 s | 2.30 s |
  | Peak Dart processes | 26 | 8 |
  | Peak Dart RSS | 145.1 MiB | 41.6 MiB |

  The stock peak varies with process scheduling. The patched build remained at Stencil's configured limit of 8. All 152 files in the generated component output were byte-identical.
- A 200-component run also remained capped at 8 Dart processes.

## Other information

Using a reusable `AsyncCompiler` would avoid process startup per transform, but its public modern API cannot consume this plugin's legacy importer and function options. This patch preserves that compatibility while fixing the unbounded process fan-out. It does not prevent a later migration to the modern API.
